### PR TITLE
Use XDG directories on linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@
 ### <a href="https://tenacityaudio.org/">Tenacity</a> (FOSS Audacity fork)
 
 1. Open Preferences and choose Custom theme under Interface tab. Close the preferences to update the changes.
-2. Drop chosen the ImageCache.png from to `%appdata%/tenacity/Theme` folder (Windows) or `~/.tenacity-data/Theme` (Linux) (or `~/.var/app/org.tenacityaudio.Tenacity/config/Theme/` if using Flatpak's) or `~/Library/Application Support/tenacity/Theme` (Mac),
+2. Drop chosen the ImageCache.png from to `%appdata%/tenacity/Theme` folder (Windows) or `$XDG_DATA_HOME/tenacity/Theme` (Linux) (or `~/.var/app/org.tenacityaudio.Tenacity/config/Theme/` if using Flatpak's) or `~/Library/Application Support/tenacity/Theme` (Mac),
 3. Open the Preferences once again and choose Theme.
 4. Then, click Load Theme Cache to load the theme from the folder.
 


### PR DESCRIPTION
Since audacity [3.2.0](https://github.com/audacity/audacity/releases/tag/Audacity-3.2.0):
> Audacity now uses XDG directories on Linux.
Note: If you are upgrading from a previous version, Audacity will keep using the ~/.audacity-data and ~/.audacity folders until you delete them.

So `~/.audacity-data` is essentially deprecated, and shouldn't be used. Instead, use `$XDG_DATA_HOME/audacity/Theme` (on most systems, it evaluates to `~/.local/share/audacity/Theme`)